### PR TITLE
Add support for opening databases from direct file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,21 @@ If you prefer using native Swift instead of Kotlin Multiplatform, we maintain a 
 ### Kotlin (Android)
 
 ```kotlin
-// Initialize from direct file path
-val factory = BibleDatabaseFactory(context = applicationContext)
-val database = factory.create(filePath = "/path/to/bible.db")
-val provider = BibleProvider.create(database = database)
+// Copy bible.db from assets to app directory if it doesn't exist
+val dbFile = File(applicationContext.filesDir, "bible.db")
+if (!dbFile.exists()) {
+    applicationContext.assets.open("bible.db").use { input ->
+        FileOutputStream(dbFile).use { output ->
+            input.copyTo(output)
+        }
+    }
+}
+
+// Initialize with the database file path
+val provider = BibleProvider.create(
+    dbFactory = BibleDatabaseFactory(context = applicationContext),
+    filePath = dbFile.absolutePath
+)
 
 // Search
 val results = provider.search(
@@ -77,10 +88,16 @@ val results = provider.search(
 ### Swift (iOS/macOS)
 
 ```swift
-// Initialize from direct file path
-let factory = BibleDatabaseFactory()
-let database = factory.create(filePath: "/path/to/bible.db")
-let provider = BibleProvider.create(database: database)
+// Get the bible.db path from the app bundle
+guard let dbPath = Bundle.main.path(forResource: "bible", ofType: "db") else {
+    fatalError("bible.db not found in bundle")
+}
+
+// Initialize with the database file path
+let provider = BibleProvider.companion.create(
+    dbFactory: BibleDatabaseFactory(),
+    filePath: dbPath
+)
 
 // Search
 let results = try await provider.search(

--- a/README.md
+++ b/README.md
@@ -62,14 +62,10 @@ If you prefer using native Swift instead of Kotlin Multiplatform, we maintain a 
 ### Kotlin (Android)
 
 ```kotlin
-// Initialize
-val provider = BibleProvider.create(
-    dbFactory = BibleDatabaseFactory(
-        context = applicationContext,
-        replaceDatabase = false,
-        completionHandler = {}
-    )
-)
+// Initialize from direct file path
+val factory = BibleDatabaseFactory(context = applicationContext)
+val database = factory.create(filePath = "/path/to/bible.db")
+val provider = BibleProvider.create(database = database)
 
 // Search
 val results = provider.search(
@@ -81,13 +77,10 @@ val results = provider.search(
 ### Swift (iOS/macOS)
 
 ```swift
-// Initialize
-let provider = BibleProvider.create(
-    dbFactory: BibleDatabaseFactory(
-        replaceDatabase: false,
-        completionHandler: {}
-    )
-)
+// Initialize from direct file path
+let factory = BibleDatabaseFactory()
+let database = factory.create(filePath: "/path/to/bible.db")
+let provider = BibleProvider.create(database: database)
 
 // Search
 let results = try await provider.search(

--- a/androidApp/src/main/java/com/aarkaystudio/biblekitapp/MainActivity.kt
+++ b/androidApp/src/main/java/com/aarkaystudio/biblekitapp/MainActivity.kt
@@ -14,11 +14,31 @@ import androidx.compose.ui.Modifier
 import com.aarkaystudio.biblekit.BibleDatabaseFactory
 import com.aarkaystudio.biblekit.BibleProvider
 import com.aarkaystudio.biblekitapp.ui.theme.biblekitappTheme
+import java.io.File
+import java.io.FileOutputStream
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // Copy bible.db from assets to app directory if it doesn't exist
+        val dbFile = File(applicationContext.filesDir, "bible.db")
+        if (!dbFile.exists()) {
+            applicationContext.assets.open("bible.db").use { input ->
+                FileOutputStream(dbFile).use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+
+        // Initialize BibleProvider with the new filePath API
+        val provider =
+            BibleProvider.create(
+                dbFactory = BibleDatabaseFactory(context = applicationContext),
+                filePath = dbFile.absolutePath,
+            )
+
         setContent {
             biblekitappTheme {
                 Surface {
@@ -30,17 +50,7 @@ class MainActivity : ComponentActivity() {
                                     .padding(innerPadding)
                                     .imePadding(),
                         ) {
-                            SearchScreen(
-                                provider =
-                                    BibleProvider.create(
-                                        dbFactory =
-                                            BibleDatabaseFactory(
-                                                context = applicationContext,
-                                                replaceDatabase = false,
-                                                completionHandler = {},
-                                            ),
-                                    ),
-                            )
+                            SearchScreen(provider = provider)
                         }
                     }
                 }

--- a/biblekit-db/api/biblekit-db.api
+++ b/biblekit-db/api/biblekit-db.api
@@ -10,6 +10,7 @@ public final class com/aarkaystudio/biblekitdb/BibleDatabase$Companion {
 
 public final class com/aarkaystudio/biblekitdb/BibleDatabaseKt {
 	public static final fun createDatabase (Lcom/aarkaystudio/biblekitdb/DriverFactory;ZLkotlin/jvm/functions/Function0;)Lcom/aarkaystudio/biblekitdb/BibleDatabase;
+	public static final fun createDatabase (Ljava/lang/String;Lcom/aarkaystudio/biblekitdb/DriverFactory;)Lcom/aarkaystudio/biblekitdb/BibleDatabase;
 }
 
 public final class com/aarkaystudio/biblekitdb/BibleStoreProvider {
@@ -43,6 +44,7 @@ public final class com/aarkaystudio/biblekitdb/DatabaseQueries : app/cash/sqldel
 public final class com/aarkaystudio/biblekitdb/DriverFactory {
 	public fun <init> (Landroid/content/Context;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Landroid/content/Context;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun createDriver (Ljava/lang/String;)Lapp/cash/sqldelight/db/SqlDriver;
 	public final fun createDriver (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/cash/sqldelight/db/SqlDriver;
 }
 

--- a/biblekit-db/src/androidMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.android.kt
+++ b/biblekit-db/src/androidMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.android.kt
@@ -1,8 +1,10 @@
 package com.aarkaystudio.biblekitdb
 
 import android.content.Context
+import android.content.ContextWrapper
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
 
@@ -10,6 +12,15 @@ public actual class DriverFactory(
     private val context: Context,
     private val logBlock: ((String) -> Unit)? = null,
 ) {
+    /**
+     * Creates a database driver from assets.
+     * Copies the database from assets to the app's database directory.
+     */
+    @Deprecated(
+        message = "Use createDriver(filePath: String) instead to open databases directly without copying",
+        replaceWith = ReplaceWith("createDriver(filePath)"),
+        level = DeprecationLevel.WARNING,
+    )
     public actual fun createDriver(
         name: String?,
         replaceDatabase: Boolean,
@@ -39,4 +50,38 @@ public actual class DriverFactory(
             logBlock?.let { it(text) }
         }
     }
+
+    /**
+     * Creates a database driver from a direct file path.
+     * Opens the database directly without copying.
+     */
+    public actual fun createDriver(filePath: String): SqlDriver {
+        // Create a custom context that returns the full path for getDatabasePath
+        val customContext = CustomDatabasePathContext(context, filePath)
+
+        // Extract just the filename from the path for AndroidSqliteDriver
+        val fileName = File(filePath).name
+
+        return LogSqliteDriver(
+            sqlDriver =
+                AndroidSqliteDriver(
+                    schema = BibleDatabase.Schema,
+                    context = customContext,
+                    name = fileName,
+                ),
+        ) { text ->
+            logBlock?.let { it(text) }
+        }
+    }
+}
+
+/**
+ * Custom ContextWrapper that allows specifying a custom database path.
+ * This is used to open databases from absolute file paths.
+ */
+private class CustomDatabasePathContext(
+    base: Context,
+    private val databasePath: String,
+) : ContextWrapper(base) {
+    override fun getDatabasePath(name: String): File = File(databasePath)
 }

--- a/biblekit-db/src/appleMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.apple.kt
+++ b/biblekit-db/src/appleMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.apple.kt
@@ -22,13 +22,22 @@ import platform.Foundation.stringByAppendingPathComponent
 public actual class DriverFactory(
     private val logBlock: ((String) -> Unit)? = null,
 ) {
+    /**
+     * Creates a database driver from bundle.
+     * Copies the database from bundle to Application Support directory.
+     */
+    @Deprecated(
+        message = "Use createDriver(filePath: String) instead to open databases directly without copying",
+        replaceWith = ReplaceWith("createDriver(filePath)"),
+        level = DeprecationLevel.WARNING,
+    )
     @OptIn(ExperimentalForeignApi::class)
     public actual fun createDriver(
         name: String?,
         replaceDatabase: Boolean,
         completionHandler: (Boolean) -> Unit,
-    ): SqlDriver {
-        return if (name != null) {
+    ): SqlDriver =
+        if (name != null) {
             val fileManager = NSFileManager.defaultManager
             val documentsPath =
                 NSSearchPathForDirectoriesInDomains(
@@ -84,7 +93,7 @@ public actual class DriverFactory(
                 completionHandler(false)
             }
 
-            return LogSqliteDriver(
+            LogSqliteDriver(
                 sqlDriver =
                     NativeSqliteDriver(
                         schema = BibleDatabase.Schema,
@@ -109,6 +118,39 @@ public actual class DriverFactory(
             ) { text ->
                 logBlock?.let { it(text) }
             }
+        }
+
+    /**
+     * Creates a database driver from a direct file path.
+     * Opens the database directly without copying.
+     */
+    public actual fun createDriver(filePath: String): SqlDriver {
+        // Split the file path into directory and filename
+        // DatabaseConfiguration.name cannot contain path separators, so we use basePath for the directory
+        val lastSeparator = filePath.lastIndexOf('/')
+        val (directory, filename) =
+            if (lastSeparator != -1) {
+                filePath.substring(0, lastSeparator) to filePath.substring(lastSeparator + 1)
+            } else {
+                null to filePath
+            }
+
+        return LogSqliteDriver(
+            sqlDriver =
+                NativeSqliteDriver(
+                    DatabaseConfiguration(
+                        name = filename,
+                        version = BibleDatabase.Schema.version.toInt(),
+                        create = { con -> wrapConnection(con) { BibleDatabase.Schema.create(it) } },
+                        inMemory = false,
+                        extendedConfig =
+                            DatabaseConfiguration.Extended(
+                                basePath = directory,
+                            ),
+                    ),
+                ),
+        ) { text ->
+            logBlock?.let { it(text) }
         }
     }
 }

--- a/biblekit-db/src/appleMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.apple.kt
+++ b/biblekit-db/src/appleMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.apple.kt
@@ -132,7 +132,10 @@ public actual class DriverFactory(
             if (lastSeparator != -1) {
                 filePath.substring(0, lastSeparator) to filePath.substring(lastSeparator + 1)
             } else {
-                null to filePath
+                throw IllegalArgumentException(
+                    "filePath must contain a directory path. Received: '$filePath'. " +
+                        "Use an absolute path like '/path/to/database.db'",
+                )
             }
 
         return LogSqliteDriver(

--- a/biblekit-db/src/commonMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.kt
+++ b/biblekit-db/src/commonMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.kt
@@ -15,28 +15,48 @@ import kotlin.coroutines.resumeWithException
  */
 public expect class DriverFactory {
     /**
-     * Creates a platform-specific SQLite database driver.
+     * Creates a platform-specific SQLite database driver from assets/bundle.
+     * The database file will be copied from assets/bundle to a writable location.
      *
-     * @param name The name of the database file
+     * @param name The name of the database file in assets/bundle
      * @param replaceDatabase Whether to replace the existing database with a new one
      * @param completionHandler Callback to handle completion of driver creation
      * @return A platform-specific [SqlDriver] implementation
      */
+    @Deprecated(
+        message = "Use createDriver(filePath: String) instead to open databases directly without copying",
+        replaceWith = ReplaceWith("createDriver(filePath)"),
+        level = DeprecationLevel.WARNING,
+    )
     public fun createDriver(
         name: String?,
         replaceDatabase: Boolean,
         completionHandler: (Boolean) -> Unit,
     ): SqlDriver
+
+    /**
+     * Creates a platform-specific SQLite database driver from a direct file path.
+     * No copying occurs - the database is opened directly from the provided path in read-only mode.
+     *
+     * @param filePath The absolute file path to the database file
+     * @return A platform-specific [SqlDriver] implementation
+     */
+    public fun createDriver(filePath: String): SqlDriver
 }
 
 /**
- * Creates and initializes the Bible database.
+ * Creates and initializes the Bible database from assets/bundle.
  *
  * @param driverFactory Platform-specific factory for creating the database driver
  * @param replaceDatabase Whether to replace the existing database with a new one
  * @param completionHandler Callback that receives the new database version after successful creation
  * @return Initialized [BibleDatabase] instance
  */
+@Deprecated(
+    message = "Use createDatabase(filePath, driverFactory) instead to open databases directly without copying",
+    replaceWith = ReplaceWith("createDatabase(filePath, driverFactory)"),
+    level = DeprecationLevel.WARNING,
+)
 public fun createDatabase(
     driverFactory: DriverFactory,
     replaceDatabase: Boolean,
@@ -52,6 +72,23 @@ public fun createDatabase(
                 }
             },
         )
+    val database = BibleDatabase(driver)
+    return database
+}
+
+/**
+ * Creates and initializes the Bible database from a direct file path.
+ * No copying occurs - the database is opened directly from the provided path.
+ *
+ * @param filePath The absolute file path to the database file
+ * @param driverFactory Platform-specific factory for creating the database driver
+ * @return Initialized [BibleDatabase] instance
+ */
+public fun createDatabase(
+    filePath: String,
+    driverFactory: DriverFactory,
+): BibleDatabase {
+    val driver = driverFactory.createDriver(filePath = filePath)
     val database = BibleDatabase(driver)
     return database
 }

--- a/biblekit/api/biblekit.api
+++ b/biblekit/api/biblekit.api
@@ -22,7 +22,6 @@ public final class com/aarkaystudio/biblekit/BibleProvider {
 public final class com/aarkaystudio/biblekit/BibleProvider$Companion {
 	public final fun create (Lcom/aarkaystudio/biblekit/BibleDatabaseFactory;)Lcom/aarkaystudio/biblekit/BibleProvider;
 	public final fun create (Lcom/aarkaystudio/biblekit/BibleDatabaseFactory;Ljava/lang/String;)Lcom/aarkaystudio/biblekit/BibleProvider;
-	public final fun create (Lcom/aarkaystudio/biblekitdb/BibleDatabase;)Lcom/aarkaystudio/biblekit/BibleProvider;
 }
 
 public final class com/aarkaystudio/biblekit/data/BookCollection {

--- a/biblekit/api/biblekit.api
+++ b/biblekit/api/biblekit.api
@@ -1,6 +1,8 @@
 public final class com/aarkaystudio/biblekit/BibleDatabaseFactory {
+	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;ZLkotlin/jvm/functions/Function0;)V
 	public final fun create ()Lcom/aarkaystudio/biblekitdb/BibleDatabase;
+	public final fun create (Ljava/lang/String;)Lcom/aarkaystudio/biblekitdb/BibleDatabase;
 }
 
 public final class com/aarkaystudio/biblekit/BibleProvider {
@@ -19,6 +21,8 @@ public final class com/aarkaystudio/biblekit/BibleProvider {
 
 public final class com/aarkaystudio/biblekit/BibleProvider$Companion {
 	public final fun create (Lcom/aarkaystudio/biblekit/BibleDatabaseFactory;)Lcom/aarkaystudio/biblekit/BibleProvider;
+	public final fun create (Lcom/aarkaystudio/biblekit/BibleDatabaseFactory;Ljava/lang/String;)Lcom/aarkaystudio/biblekit/BibleProvider;
+	public final fun create (Lcom/aarkaystudio/biblekitdb/BibleDatabase;)Lcom/aarkaystudio/biblekit/BibleProvider;
 }
 
 public final class com/aarkaystudio/biblekit/data/BookCollection {

--- a/biblekit/src/androidMain/kotlin/com/aarkaystudio/biblekit/BibleDatabaseFactory.android.kt
+++ b/biblekit/src/androidMain/kotlin/com/aarkaystudio/biblekit/BibleDatabaseFactory.android.kt
@@ -6,15 +6,45 @@ import com.aarkaystudio.biblekitdb.DriverFactory
 import com.aarkaystudio.biblekitdb.createDatabase
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-public actual class BibleDatabaseFactory(
-    private val context: Context,
-    private val replaceDatabase: Boolean,
-    private val completionHandler: () -> Unit,
-) {
-    public actual fun create(): BibleDatabase =
-        createDatabase(
-            driverFactory = DriverFactory(context = context),
-            replaceDatabase = replaceDatabase,
-            completionHandler = completionHandler,
+public actual class BibleDatabaseFactory
+    @Deprecated(
+        message = "Use BibleDatabaseFactory(context) and create(filePath) instead to open databases directly without copying",
+        replaceWith = ReplaceWith("BibleDatabaseFactory(context)"),
+        level = DeprecationLevel.WARNING,
+    )
+    constructor(
+        private val context: Context,
+        private val replaceDatabase: Boolean,
+        private val completionHandler: () -> Unit,
+    ) {
+        /**
+         * Constructor for creating a factory that opens databases from file paths.
+         *
+         * @param context The Android application context
+         */
+        public constructor(context: Context) : this(context, false, {})
+
+        @Deprecated(
+            message = "Use create(filePath) instead to open databases directly without copying",
+            replaceWith = ReplaceWith("create(filePath)"),
+            level = DeprecationLevel.WARNING,
         )
-}
+        public actual fun create(): BibleDatabase =
+            createDatabase(
+                driverFactory = DriverFactory(context = context),
+                replaceDatabase = replaceDatabase,
+                completionHandler = completionHandler,
+            )
+
+        /**
+         * Creates a database using a direct file path (no asset copying).
+         *
+         * @param filePath The absolute file path to the database file
+         * @return Initialized [BibleDatabase] instance
+         */
+        public actual fun create(filePath: String): BibleDatabase =
+            createDatabase(
+                filePath = filePath,
+                driverFactory = DriverFactory(context = context),
+            )
+    }

--- a/biblekit/src/appleMain/kotlin/com/aarkaystudio/biblekit/BibleDatabaseFactory.apple.kt
+++ b/biblekit/src/appleMain/kotlin/com/aarkaystudio/biblekit/BibleDatabaseFactory.apple.kt
@@ -4,14 +4,42 @@ import com.aarkaystudio.biblekitdb.BibleDatabase
 import com.aarkaystudio.biblekitdb.DriverFactory
 import com.aarkaystudio.biblekitdb.createDatabase
 
-public actual class BibleDatabaseFactory(
-    private val replaceDatabase: Boolean,
-    private val completionHandler: () -> Unit,
-) {
-    public actual fun create(): BibleDatabase =
-        createDatabase(
-            driverFactory = DriverFactory(),
-            replaceDatabase = replaceDatabase,
-            completionHandler = completionHandler,
+public actual class BibleDatabaseFactory
+    @Deprecated(
+        message = "Use BibleDatabaseFactory() and create(filePath) instead to open databases directly without copying",
+        replaceWith = ReplaceWith("BibleDatabaseFactory()"),
+        level = DeprecationLevel.WARNING,
+    )
+    constructor(
+        private val replaceDatabase: Boolean,
+        private val completionHandler: () -> Unit,
+    ) {
+        /**
+         * Constructor for creating a factory that opens databases from file paths.
+         */
+        public constructor() : this(false, {})
+
+        @Deprecated(
+            message = "Use create(filePath) instead to open databases directly without copying",
+            replaceWith = ReplaceWith("create(filePath)"),
+            level = DeprecationLevel.WARNING,
         )
-}
+        public actual fun create(): BibleDatabase =
+            createDatabase(
+                driverFactory = DriverFactory(),
+                replaceDatabase = replaceDatabase,
+                completionHandler = completionHandler,
+            )
+
+        /**
+         * Creates a database using a direct file path.
+         *
+         * @param filePath The absolute file path to the database file
+         * @return Initialized [BibleDatabase] instance
+         */
+        public actual fun create(filePath: String): BibleDatabase =
+            createDatabase(
+                filePath = filePath,
+                driverFactory = DriverFactory(),
+            )
+    }

--- a/biblekit/src/commonMain/kotlin/com/aarkaystudio/biblekit/BibleDatabaseFactory.kt
+++ b/biblekit/src/commonMain/kotlin/com/aarkaystudio/biblekit/BibleDatabaseFactory.kt
@@ -4,5 +4,12 @@ import com.aarkaystudio.biblekitdb.BibleDatabase
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 public expect class BibleDatabaseFactory {
+    @Deprecated(
+        message = "Use create(filePath) instead to open databases directly without copying",
+        replaceWith = ReplaceWith("create(filePath)"),
+        level = DeprecationLevel.WARNING,
+    )
     internal fun create(): BibleDatabase
+
+    internal fun create(filePath: String): BibleDatabase
 }

--- a/biblekit/src/commonMain/kotlin/com/aarkaystudio/biblekit/BibleProvider.kt
+++ b/biblekit/src/commonMain/kotlin/com/aarkaystudio/biblekit/BibleProvider.kt
@@ -44,18 +44,6 @@ public class BibleProvider internal constructor(
 
         /**
          * Creates a new instance of [BibleProvider] with a default [BibleStoreService] implementation.
-         * This factory method takes a database instance directly.
-         *
-         * @param database The [BibleDatabase] instance to use for data access
-         * @return A new [BibleProvider] instance ready for use
-         */
-        public fun create(database: BibleDatabase): BibleProvider {
-            val provider = BibleStoreProvider.create(db = database)
-            return BibleProvider(store = DefaultBibleStoreService(provider = provider))
-        }
-
-        /**
-         * Creates a new instance of [BibleProvider] with a default [BibleStoreService] implementation.
          * This factory method sets up the database connection using the provided factory and file path.
          *
          * @param dbFactory The [BibleDatabaseFactory] instance to use for creating the database

--- a/biblekit/src/commonMain/kotlin/com/aarkaystudio/biblekit/BibleProvider.kt
+++ b/biblekit/src/commonMain/kotlin/com/aarkaystudio/biblekit/BibleProvider.kt
@@ -5,6 +5,7 @@ import com.aarkaystudio.biblekit.model.ChapterReference
 import com.aarkaystudio.biblekit.model.Reference
 import com.aarkaystudio.biblekit.model.Verse
 import com.aarkaystudio.biblekit.model.VerseID
+import com.aarkaystudio.biblekitdb.BibleDatabase
 import com.aarkaystudio.biblekitdb.BibleStoreProvider
 
 /**
@@ -31,8 +32,41 @@ public class BibleProvider internal constructor(
          * @param dbFactory The [BibleDatabaseFactory] instance to use for data access
          * @return A new [BibleProvider] instance ready for use
          */
+        @Deprecated(
+            message = "Use create(database) instead with BibleDatabaseFactory.create(filePath) for direct file path access",
+            replaceWith = ReplaceWith("create(database)"),
+            level = DeprecationLevel.WARNING,
+        )
         public fun create(dbFactory: BibleDatabaseFactory): BibleProvider {
             val provider = BibleStoreProvider.create(db = dbFactory.create())
+            return BibleProvider(store = DefaultBibleStoreService(provider = provider))
+        }
+
+        /**
+         * Creates a new instance of [BibleProvider] with a default [BibleStoreService] implementation.
+         * This factory method takes a database instance directly.
+         *
+         * @param database The [BibleDatabase] instance to use for data access
+         * @return A new [BibleProvider] instance ready for use
+         */
+        public fun create(database: BibleDatabase): BibleProvider {
+            val provider = BibleStoreProvider.create(db = database)
+            return BibleProvider(store = DefaultBibleStoreService(provider = provider))
+        }
+
+        /**
+         * Creates a new instance of [BibleProvider] with a default [BibleStoreService] implementation.
+         * This factory method sets up the database connection using the provided factory and file path.
+         *
+         * @param dbFactory The [BibleDatabaseFactory] instance to use for creating the database
+         * @param filePath The absolute path to the Bible database file
+         * @return A new [BibleProvider] instance ready for use
+         */
+        public fun create(
+            dbFactory: BibleDatabaseFactory,
+            filePath: String,
+        ): BibleProvider {
+            val provider = BibleStoreProvider.create(db = dbFactory.create(filePath))
             return BibleProvider(store = DefaultBibleStoreService(provider = provider))
         }
     }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -5,12 +5,18 @@ import SwiftUI
 struct iOSApp: App {
     // MARK: - Properties
     @Bindable var viewModel = SearchViewModel(
-        bibleProvider: BibleProvider.companion.create(
-            dbFactory: BibleDatabaseFactory(
-                replaceDatabase: false,
-                completionHandler: {}
+        bibleProvider: {
+            // Get the bible.db path from the app bundle
+            guard let dbPath = Bundle.main.path(forResource: "bible", ofType: "db") else {
+                fatalError("bible.db not found in bundle")
+            }
+
+            // Initialize BibleProvider with the new filePath API
+            return BibleProvider.companion.create(
+                dbFactory: BibleDatabaseFactory(),
+                filePath: dbPath
             )
-        )
+        }()
     )
 
     // MARK: - Body


### PR DESCRIPTION
- Added new `create(filePath: String)` API to `BibleDatabaseFactory` and `BibleProvider` for opening databases directly from file paths without copying
- Deprecated the old asset/bundle-based database initialization approach