### PR TITLE
Replace Osmerion SQLite with Requery SQLite for Android

### DIFF
--- a/biblekit-db/build.gradle.kts
+++ b/biblekit-db/build.gradle.kts
@@ -46,7 +46,7 @@ kotlin {
 
         androidMain.dependencies {
             implementation(libs.sqldelight.android)
-            implementation(libs.osmerion.sqlite.android)
+            implementation(libs.sqlite.android)
         }
 
         androidUnitTest.dependencies {

--- a/biblekit-db/src/androidMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.android.kt
+++ b/biblekit-db/src/androidMain/kotlin/com/aarkaystudio/biblekitdb/BibleDatabase.android.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
-import com.osmerion.android.database.sqlite.OsmerionSQLiteOpenHelperFactory
+import io.requery.android.database.sqlite.RequerySQLiteOpenHelperFactory
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
@@ -51,7 +51,7 @@ public actual class DriverFactory(
                     schema = BibleDatabase.Schema,
                     context = context,
                     name = dbName,
-                    factory = OsmerionSQLiteOpenHelperFactory(),
+                    factory = RequerySQLiteOpenHelperFactory(),
                 ),
         ) { text ->
             logBlock?.let { it(text) }
@@ -75,7 +75,7 @@ public actual class DriverFactory(
                     schema = BibleDatabase.Schema,
                     context = customContext,
                     name = fileName,
-                    factory = OsmerionSQLiteOpenHelperFactory(),
+                    factory = RequerySQLiteOpenHelperFactory(),
                 ),
         ) { text ->
             logBlock?.let { it(text) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,11 @@ android-targetSdk = "34"
 kotlin = "2.3.0"
 kotlinx = "1.10.2"
 sqldelight = "2.2.1"
-osmerion-sqlite = "0.7.0"
 
 [libraries]
 # Database & Storage (SQLDelight)
 sqldelight-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
-osmerion-sqlite-android = { module = "com.osmerion.sqlite.android:sqlite-android", version.ref = "osmerion-sqlite" }
+sqlite-android = { module = "com.github.requery:sqlite-android", version = "3.49.0" }
 sqldelight-native = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-jvm = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ dependencyResolutionManagement {
             }
         }
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
Replace Osmerion SQLite with Requery SQLite library for Android. Osmerion does not support Android's 16KB page size alignment requirement needed for newer devices, while Requery SQLite (3.49.0) provides this support.