### PR TITLE
Upgrade AGP, Gradle, Kotlin and bump Android SDK levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BibleKit KMP
 
-[![Kotlin](https://img.shields.io/badge/kotlin-2.3.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.4.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-orange.svg?logo=kotlin)](https://kotlinlang.org/docs/multiplatform.html)
 [![Maven Central](https://img.shields.io/maven-central/v/com.aarkaystudio.biblekit/biblekit)](https://central.sonatype.com/artifact/com.aarkaystudio.biblekit/biblekit)
 [![Documentation](https://img.shields.io/badge/docs-dokka-green)](https://versewell.github.io/biblekit-kmp)
@@ -18,7 +18,7 @@ BibleKit KMP is a Kotlin Multiplatform library that provides Bible-related funct
 
 ## Requirements
 
-- Android: minSdk 24+
+- Android: minSdk 26+
 - iOS: 13.0+
 - macOS: 10.15+
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace = "com.aarkaystudio.biblekitapp"
-    compileSdk = 36
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {
         applicationId = "com.aarkaystudio.biblekitapp"
-        minSdk = 24
-        targetSdk = 35
+        minSdk = libs.versions.android.minSdk.get().toInt()
+        targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = 1
         versionName = "1.0"
 
@@ -44,9 +44,9 @@ android {
 }
 
 dependencies {
-    implementation(libs.core.ktx)
-    implementation(libs.lifecycle.runtime.ktx)
-    implementation(libs.activity.compose)
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.activity.compose)
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)
@@ -55,8 +55,8 @@ dependencies {
     implementation(libs.compose.material.icons)
     implementation(projects.biblekit)
     testImplementation(libs.junit)
-    androidTestImplementation(libs.junit.ext)
-    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
     debugImplementation(libs.compose.ui.tooling)

--- a/biblekit-db/build.gradle.kts
+++ b/biblekit-db/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -90,7 +89,7 @@ sqldelight {
 mavenPublishing {
     coordinates("com.aarkaystudio.biblekit", "biblekit-db", "0.2.1")
 
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
 
     pom {

--- a/biblekit/build.gradle.kts
+++ b/biblekit/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
@@ -93,7 +92,7 @@ listOf(
 mavenPublishing {
     coordinates("com.aarkaystudio.biblekit", "biblekit", "0.2.1")
 
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
 
     pom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,9 @@ android.nonTransitiveRClass=true
 
 # Increase the Gradle Daemon's Heap Size:
 org.gradle.jvmargs=-Xmx4g
+
+# AGP 9's built-in Kotlin support and new DSL don't support Kotlin Multiplatform
+# (biblekit/biblekit-db apply the kotlin.multiplatform plugin) or the
+# org.jetbrains.kotlin.android plugin (androidApp), so both are disabled:
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-agp = "8.13.2"
-android-compileSdk = "36"
-android-minSdk = "24"
-android-targetSdk = "34"
-kotlin = "2.3.0"
-coroutines = "1.10.2"
-sqldelight = "2.2.1"
+agp = "9.1.1"
+android-compileSdk = "37"
+android-minSdk = "26"
+android-targetSdk = "37"
+kotlin = "2.4.0"
+coroutines = "1.11.0"
+sqldelight = "2.3.2"
 
 [libraries]
 # Database & Storage (SQLDelight)
@@ -16,15 +16,15 @@ sqldelight-jvm = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 
 # Logging
-slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "2.0.17" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "2.0.18" }
 
 # Android Core & Lifecycle Dependencies
-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.17.0" }
-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version = "2.10.0" }
-activity-compose = { group = "androidx.activity", name = "activity-compose", version = "1.12.2" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.19.0" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version = "2.11.0" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version = "1.13.0" }
 
 # Jetpack Compose UI Components
-compose-bom = { group = "androidx.compose", name = "compose-bom", version = "2026.01.00" }
+compose-bom = { group = "androidx.compose", name = "compose-bom", version = "2026.06.01" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
@@ -40,8 +40,7 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 
 # Testing Libraries
 junit = { group = "junit", name = "junit", version = "4.13.2" }
-junit-ext = { module = "androidx.test.ext:junit", version = "1.3.0" }
-espresso-core = { module = "androidx.test.espresso:espresso-core", version = "3.7.0" }
+androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version = "3.7.0" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 [plugins]
@@ -51,18 +50,18 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-jetbrains-compose = { id = "org.jetbrains.compose", version = "1.9.3" }
+jetbrains-compose = { id = "org.jetbrains.compose", version = "1.11.1" }
 
 # Code Generation & Processing
 ksp = { id = "com.google.devtools.ksp", version = "2.3.4" }
 sql-delight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
-skie = { id = "co.touchlab.skie", version = "0.10.9" }
+skie = { id = "co.touchlab.skie", version = "0.10.13" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 # Development Tools
-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.4" }
-dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
+kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.9" }
+dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.18.1" }
 
 # Publishing
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.32.0" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.37.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgrade AGP 8.13.2 → 9.1.1, Gradle wrapper 8.14.3 → 9.3.1, Kotlin 2.3.0 → 2.4.0
- Bump compileSdk/targetSdk to 37 (Android 17) and minSdk to 26
- Bump coroutines, sqldelight, compose-bom, skie, kover, dokka, vanniktech-mavenPublish, and rename AndroidX version catalog aliases to `androidx-` prefix
- Update `publishToMavenCentral()` call for the new vanniktech-mavenPublish API (SonatypeHost param removed)

## Test plan
- [x] Confirmed the project builds successfully with AGP 9.1.1 / Kotlin 2.4.0
- [x] CI passes on this PR